### PR TITLE
feature/NGM-5321-emoji-picker-not-as-next-sibling

### DIFF
--- a/js/jquery.emojiarea.js
+++ b/js/jquery.emojiarea.js
@@ -365,7 +365,10 @@
 			});
 		}
 
-    $textarea.after("<i class='bu-icon bu-icon--emoji-smiley emoji-picker-open-button emoji-picker " + this.options.popupButtonClasses + "' data-id='" + id + "' data-type='picker'></i>");
+    // Instead of adding right after, add it as the last child of parent.
+    // This is because the styling for inputs labels depends on the
+    // textarea being the previous sibling, and we do not want to break that.
+    $textarea.parent().append("<i class='bu-icon bu-icon--emoji-smiley emoji-picker-open-button emoji-picker " + this.options.popupButtonClasses + "' data-id='" + id + "' data-type='picker'></i>");
 
 		this.setup();
 	};


### PR DESCRIPTION
Basically my stuff relies on textarea and input labels to be adjacent
siblings for CSS selectors, so add the emoji picker as the last child
of the parent as opposed to the next sibling